### PR TITLE
fix(FX-0001): Improve docs, security, CI pipeline, and lint coverage

### DIFF
--- a/.config/ansible-lint.yaml
+++ b/.config/ansible-lint.yaml
@@ -12,5 +12,3 @@ exclude_paths:
   - .github
   - .pre-commit-config.yaml
   - .vscode
-  - libs/common
-  - libs/dhis2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   lint:
@@ -13,3 +16,18 @@ jobs:
         python-version: "3.12"
     - name: Lint the project
       uses: pre-commit/action@v3.0.1
+
+  syntax-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install Ansible
+      run: pip install ansible
+    - name: Install Ansible collections
+      run: ansible-galaxy collection install -r requirements.yml
+    - name: Playbook syntax check
+      run: ansible-playbook --syntax-check -i inventories/his_servers plays/install_dhis2.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,30 @@
 ---
+default_language_version:
+  python: python3.12
 
 ci:
   autoupdate_schedule: monthly
 
 default_stages:
-- commit
+  - pre-commit
+
 exclude: docs|migrations|.git|.tox|deploy|bin
 fail_fast: false
 
 repos:
-- hooks:
-  - id: check-toml
-  - id: check-vcs-permalinks
-  - exclude: "/templates/"
-    id: check-yaml
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
-  repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-toml
+      - id: check-vcs-permalinks
+      - id: check-yaml
+        exclude: "/templates/"
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
-- hooks:
-  - id: ansible-lint
-  repo: https://github.com/ansible/ansible-lint
-  rev: v24.2.0
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v6.22.2
+    hooks:
+      - id: ansible-lint
+        additional_dependencies:
+          - ansible-core==2.16.6

--- a/README.md
+++ b/README.md
@@ -26,24 +26,24 @@ Repository directory structure
 
 ```
 dhis2-deployment-playbook
-└── inventories - host configurations for different environments
-    ├── his_servers - generic name for this deployment
-    |   ├── group_vars - for variables meant to affect a collection of servers
-    |   ├── host_vars - for variables meant to affect specific servers
-    |   └── hosts - essential file for grouping hosts
-    |
-    ├── libs - collection of roles used to defined reusable behavior
-    |   ├── caddy - caddy server installation role
-    |   ├── common - essential packages role
-    |   ├── dhis2 - dhis2 installation role
-    |   └── postgresql - postgreSQL installation role
-    ├── plays - entry point for any deployment
-    |   └── install_dhis2.yml - runs deployment on specified target host(s)
-    ├── .pre-commit-config.yaml
-    ├── ansible.cfg
-    ├── ssh.cfg
-    ├── requirements.yml
-    └── README.md
+├── inventories - host configurations for different environments
+|   └── his_servers - generic name for this deployment
+|       ├── group_vars - for variables meant to affect a collection of servers
+|       ├── host_vars - for variables meant to affect specific servers
+|       └── hosts - essential file for grouping hosts
+|
+├── libs - collection of roles used to define reusable behavior
+|   ├── caddy - caddy server installation role
+|   ├── common - essential packages role
+|   ├── dhis2 - dhis2 installation role
+|   └── postgresql - postgreSQL installation role
+├── plays - entry point for any deployment
+|   └── install_dhis2.yml - runs deployment on specified target host(s)
+├── .pre-commit-config.yaml
+├── ansible.cfg
+├── ssh.cfg
+├── requirements.yml
+└── README.md
 ```
 
 Managing secrets
@@ -51,6 +51,7 @@ Managing secrets
 - Configuration files under inventories may contain values that need to be kept secret. [Ansible vault](https://docs.ansible.com/ansible/latest/vault_guide/vault.html) helps to encrypt variables and files.
 - **NOTE**: this repo is essentially a template that can be improvised for individual use, that said, all secrets here have been
   encrypted with a simple password: `1234`
+- **WARNING**: Before using this in any real environment, you **must** re-encrypt all vault files with a strong password. Run `ansible-vault rekey <vault_file> --ask-vault-password` for each vault file to replace the default password.
 
 ```bash
 dhis2-dep-pb~$ ansible-vault encrypt inventories/his_servers/group_vars/all/vault.yml --ask-vault-password
@@ -68,7 +69,7 @@ Cloning the repo:
 -----------------
 - First, clone the repo, cd into it and run below command to install requirements:
 ```bash
-dhis2-dep-pb~$ ansible-galaxy collection install -r requirements.yaml
+dhis2-dep-pb~$ ansible-galaxy collection install -r requirements.yml
 ```
 
 Sample deployment commands:
@@ -88,6 +89,3 @@ Limit the deployment to the control node:
 Skip deploying caddy server:
 
 `dhis2-dep-pb~$ ansible-playbook -i inventories/his_servers -l "local_host" plays/install_dhis2.yml -e dhis2_caddy_as_reverse_proxy=false`
-
-## Todos:
-- improve this documentation

--- a/libs/dhis2/tasks/main.yml
+++ b/libs/dhis2/tasks/main.yml
@@ -28,25 +28,29 @@
   tags: ["dhis2"]
   block:
     - name: Reconfigure timezone data
-      ansible.builtin.command: sudo dpkg-reconfigure -f noninteractive tzdata
+      ansible.builtin.command: dpkg-reconfigure -f noninteractive tzdata
+      changed_when: false
 
     - name: Get current locale
       ansible.builtin.command: locale -a
       register: current_locale
+      changed_when: false
 
     - name: Generate the current locale (excluding POSIX and other invalid entries)
-      ansible.builtin.command: sudo locale-gen "{{ item }}"
+      ansible.builtin.command: locale-gen "{{ item }}"
       loop: "{{ current_locale.stdout_lines | difference(['POSIX', 'C']) }}"
+      changed_when: false
 
     - name: Update locale environment
       ansible.builtin.lineinfile:
         path: /etc/default/locale
         line: 'LANG={{ current_locale.stdout_lines[0] }}'
         create: true
+        mode: "0644"
 
-- name: Add the Ubuntu repository for tomcat9-user installation
+- name: Add the Ubuntu universe repository for tomcat9-user installation
   ansible.builtin.apt_repository:
-    repo: "deb http://archive.ubuntu.com/ubuntu/ jammy main universe"
+    repo: "deb http://archive.ubuntu.com/ubuntu/ {{ ansible_lsb.codename }} main universe"
     state: present
   become: true
   tags: ["dhis2"]
@@ -90,7 +94,7 @@
   tags: ["dhis2"]
 
 - name: Create tomcat instance
-  ansible.builtin.command: "sudo tomcat9-instance-create apache_tomcat"
+  ansible.builtin.command: "tomcat9-instance-create apache_tomcat"
   args:
     chdir: "/home/{{ dhis2_app_user }}"
     creates: "/home/{{ dhis2_app_user }}/apache_tomcat"

--- a/libs/postgresql/tasks/main.yml
+++ b/libs/postgresql/tasks/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.get_url:
     url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
     dest: "/etc/apt/trusted.gpg.d/pgdg.asc"
-    validate_certs: false
+    validate_certs: true
     mode: ug=rw,o=r
   become: true
   tags: ["postgres"]


### PR DESCRIPTION
- Fix README directory tree indentation and requirements.yaml typo
- Remove libs/common and libs/dhis2 from ansible-lint exclusions
- Remove redundant sudo in become blocks, add missing changed_when
- Add pull_request trigger and playbook syntax-check job to CI
- Enable validate_certs on PostgreSQL key download
- Add vault rekey warning for real deployments
- Replace hardcoded jammy repo with dynamic ansible_lsb.codename
- Update pre-commit configurations